### PR TITLE
Focus issue when opening two editor side-by-side #162

### DIFF
--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/ChromiumSelectionFunction.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/ChromiumSelectionFunction.java
@@ -1,0 +1,74 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.ide.editor.ui;
+
+import org.eclipse.glsp.server.disposable.Disposable;
+import org.eclipse.glsp.server.disposable.IDisposable;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.browser.Browser;
+import org.eclipse.swt.browser.BrowserFunction;
+import org.eclipse.swt.widgets.Control;
+
+public class ChromiumSelectionFunction extends Disposable {
+
+   private static final String FUNCTION_NAME = "mouseDownHappened";
+
+   private static final String INSTALL_FUNCTION = "document.onmousedown = function(e) {if (!e) {e = window.event;} if (e) {mouseDownHappened();}}";
+
+   private final BrowserFunction browserFunction;
+
+   public static IDisposable install(final GLSPDiagramEditor editor, final Browser browser) {
+      if ((browser.getStyle() & SWT.CHROMIUM) == 0) {
+         return new Disposable();
+      }
+      ChromiumSelectionFunction function = new ChromiumSelectionFunction(editor, browser);
+      browser.execute(INSTALL_FUNCTION);
+      return function;
+   }
+
+   public ChromiumSelectionFunction(final GLSPDiagramEditor editor, final Browser browser) {
+      browserFunction = new BrowserFunction(browser, FUNCTION_NAME) {
+
+         @Override
+         public Object function(final Object[] arguments) {
+            browser.getDisplay().asyncExec(() -> {
+               /* if on windows, we need to force the focus */
+               String osName = System.getProperty("os.name").toLowerCase();
+               if (osName.contains("win")) {
+                  browser.forceFocus();
+               } else {
+                  Control focusControl = browser.getDisplay().getFocusControl();
+                  if (focusControl != browser) {
+                     browser.setFocus();
+                  } else {
+                     return;
+                  }
+                  focusControl = browser.getDisplay().getFocusControl();
+                  if (focusControl != browser) {
+                     browser.forceFocus();
+                  }
+               }
+            });
+            return null;
+         }
+      };
+   }
+
+   @Override
+   public void dispose() {
+      this.browserFunction.dispose();
+   }
+}


### PR DESCRIPTION
Workaround for https://github.com/eclipse-glsp/glsp/issues/162

* add a custom browser function that notifies the RCP code when a mouse
down has occurred in the browser
* we will use this information to set the focus to the browser, if it is
not already the focus control

Signed-off-by: Johannes Faltermeier <jfaltermeier@eclipsesource.com>