### PR TITLE
#182: Do not dispose browser functions as they are auto-disposed

### DIFF
--- a/server/example/org.eclipse.glsp.ide.workflow.editor/WorkflowEditor.launch
+++ b/server/example/org.eclipse.glsp.ide.workflow.editor/WorkflowEditor.launch
@@ -16,7 +16,7 @@
     <stringAttribute key="featureDefaultLocation" value="workspace"/>
     <stringAttribute key="featurePluginResolution" value="workspace"/>
     <booleanAttribute key="includeOptional" value="true"/>
-    <stringAttribute key="location" value="${project_loc}/../runtime"/>
+    <stringAttribute key="location" value="${workspace_loc}/../runtime-workflowEditor"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>

--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/ChromiumKeyBindingFunction.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/ChromiumKeyBindingFunction.java
@@ -23,8 +23,6 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.NotEnabledException;
 import org.eclipse.core.commands.NotHandledException;
 import org.eclipse.core.commands.common.NotDefinedException;
-import org.eclipse.glsp.server.disposable.Disposable;
-import org.eclipse.glsp.server.disposable.IDisposable;
 import org.eclipse.jface.bindings.Binding;
 import org.eclipse.jface.bindings.keys.IKeyLookup;
 import org.eclipse.jface.bindings.keys.KeySequence;
@@ -42,7 +40,7 @@ import com.google.gson.Gson;
  * binding service of the editor. Inspired by
  * https://github.com/maketechnology/chromium.swt/issues/70.
  */
-public class ChromiumKeyBindingFunction extends Disposable {
+public class ChromiumKeyBindingFunction {
    private static final Logger LOGGER = Logger.getLogger(ChromiumKeyBindingFunction.class);
 
    private static final String FUNCTION_NAME = "$notifyKeybinding";
@@ -126,18 +124,15 @@ public class ChromiumKeyBindingFunction extends Disposable {
       }
    }
 
-   @Override
-   public void dispose() {
-      this.browserFunction.dispose();
-   }
+   public BrowserFunction getBrowserFunction() { return browserFunction; }
 
-   public static IDisposable install(final GLSPDiagramEditor editor, final Browser browser) {
+   public static Optional<BrowserFunction> install(final GLSPDiagramEditor editor, final Browser browser) {
       if ((browser.getStyle() & SWT.CHROMIUM) == 0) {
-         return new Disposable();
+         return Optional.empty();
       }
       ChromiumKeyBindingFunction function = new ChromiumKeyBindingFunction(editor, browser);
       browser.execute(INSTALL_FUNCTION);
-      return function;
+      return Optional.of(function.getBrowserFunction());
    }
 
    private static class SerializableEvent {

--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/GLSPDiagramEditor.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/GLSPDiagramEditor.java
@@ -59,8 +59,7 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
-import org.eclipse.swt.browser.ProgressAdapter;
-import org.eclipse.swt.browser.ProgressEvent;
+import org.eclipse.swt.browser.ProgressListener;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.MouseTrackListener;
@@ -345,22 +344,22 @@ public class GLSPDiagramEditor extends EditorPart implements IGotoMarker {
          event -> browser.execute(DISPATCH_MOUSE_UP_FUNCTION)));
 
       browser.setMenu(createBrowserMenu());
-      browser.addProgressListener(new ProgressAdapter() {
-         @Override
-         public void completed(final ProgressEvent event) {
-            toDispose.add(ChromiumKeyBindingFunction.install(GLSPDiagramEditor.this, browser));
-            toDispose.add(ChromiumSelectionFunction.install(GLSPDiagramEditor.this, browser));
-         }
-      });
+      browser.addProgressListener(ProgressListener.completedAdapter(event -> installBrowserFunctions()));
       browser.setUrl(createBrowserUrl(path));
       browser.refresh();
    }
 
-   private Menu createBrowserMenu() {
+   protected Menu createBrowserMenu() {
       MenuManager menuManager = new MenuManager();
       Menu menu = menuManager.createContextMenu(browser);
       getSite().registerContextMenu(menuManager, getSite().getSelectionProvider());
       return menu;
+   }
+
+   protected void installBrowserFunctions() {
+      // browser functions are automatically disposed with the browser
+      ChromiumKeyBindingFunction.install(GLSPDiagramEditor.this, browser);
+      ChromiumSelectionFunction.install(GLSPDiagramEditor.this, browser);
    }
 
    protected String createBrowserUrl(final String path) {


### PR DESCRIPTION
- Do not dispose browser functions, they are disposed with the browser
-- Also provide dedicated method for subclasses to install functions

- Fix launch config to choose a workspace-relative path location
-- Previous location depended on selected project in Eclipse
-- Previous location was always in Git-controlled area

Fixes eclipse-glsp/glsp/issues/182

Signed-off-by: Martin Fleck <mfleck@eclipsesource.com>