### PR TITLE
#435 Fix Navigation from marker to affected element is no longer working

### DIFF
--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/di/IdeActionDispatcher.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/di/IdeActionDispatcher.java
@@ -39,13 +39,17 @@ public class IdeActionDispatcher extends DefaultActionDispatcher {
    protected final ModelInitializationConstraint initializationConstraint;
 
    @Inject
-   public IdeActionDispatcher(final Injector injector, @ClientId() final String clientId,
+   public IdeActionDispatcher(@ClientId() final String clientId,
       final ModelInitializationConstraint initializationConstraint) {
       super();
       this.clientId = clientId;
       this.initializationConstraint = initializationConstraint;
       this.onModelInitialized = initializationConstraint.onInitialized();
       this.onModelInitialized.thenRun(() -> LOGGER.info("Model Initialized."));
+   }
+
+   @Inject
+   public void initInjector(final Injector injector) {
       GLSPIdeEditorPlugin.getDefaultGLSPEditorRegistry().getGLSPEditor(clientId)
          .ifPresent(editor -> editor.setInjector(injector));
    }

--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/initialization/DefaultModelInitializationConstraint.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/initialization/DefaultModelInitializationConstraint.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 
 import org.eclipse.glsp.ide.editor.actions.InitializeCanvasBoundsAction;
 import org.eclipse.glsp.server.actions.Action;
-import org.eclipse.glsp.server.features.core.model.UpdateModelAction;
+import org.eclipse.glsp.server.features.core.model.SetModelAction;
 
 /**
  * Default initialization constraint triggers after a non-empty UpdateModelAction and a subsequent
@@ -27,18 +27,18 @@ import org.eclipse.glsp.server.features.core.model.UpdateModelAction;
  */
 public class DefaultModelInitializationConstraint extends AbstractModelInitializationConstraint {
 
-   private boolean nonEmptyUpdateModelActionDispatched;
+   private boolean nonEmptySetModelActionDispatched;
 
    @Override
    protected boolean isInitializedAfter(final Action action) {
-      nonEmptyUpdateModelActionDispatched = nonEmptyUpdateModelActionDispatched || isNonEmptyUpdateModelAction(action);
-      return nonEmptyUpdateModelActionDispatched && isInitializeCanvasBoundsAction(action);
+      nonEmptySetModelActionDispatched = nonEmptySetModelActionDispatched || isNotEmptySetModelAction(action);
+      return nonEmptySetModelActionDispatched && isInitializeCanvasBoundsAction(action);
    }
 
-   private static boolean isNonEmptyUpdateModelAction(final Action action) {
-      return action instanceof UpdateModelAction
-         && ((UpdateModelAction) action).getNewRoot() != null
-         && !Objects.equals(((UpdateModelAction) action).getNewRoot().getType(), "NONE");
+   private static boolean isNotEmptySetModelAction(final Action action) {
+      return action instanceof SetModelAction
+         && ((SetModelAction) action).getNewRoot() != null
+         && !Objects.equals(((SetModelAction) action).getNewRoot().getType(), "NONE");
    }
 
    private static boolean isInitializeCanvasBoundsAction(final Action action) {


### PR DESCRIPTION
closes https://github.com/eclipse-glsp/glsp/issues/435

As already mentioned in the issue, this PR fixes the:

- `ModelInitializationConstraint` so it waits for a `SetModelAction` instead of a `UpdateModelAction` to be marked as initialized
- Move the `editor.setInjector` method from the constructor to it's own method, to ensure that the IdeActionDispatcher is fully initialized by the DI before waiting `CompletableFuture`'s are resumed