### PR TITLE
GLSP Server Error when closing GLSP Eclipse Editor #556

### DIFF
--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/GLSPDiagramEditor.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/GLSPDiagramEditor.java
@@ -52,6 +52,7 @@ import org.eclipse.glsp.server.features.navigation.NavigateToTargetAction;
 import org.eclipse.glsp.server.features.undoredo.RedoAction;
 import org.eclipse.glsp.server.features.undoredo.UndoAction;
 import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.session.ClientSessionManager;
 import org.eclipse.glsp.server.types.EditorContext;
 import org.eclipse.glsp.server.types.GLSPServerException;
 import org.eclipse.jetty.server.ServerConnector;
@@ -412,6 +413,15 @@ public class GLSPDiagramEditor extends EditorPart implements IGotoMarker {
    @Override
    public void setFocus() {
       browser.setFocus();
+   }
+
+   public void notifyAboutToBeDisposed() {
+      // we are about to be disposed. don't send and accept actions anymore
+      getClientSessionManager().thenAccept(sessionManager -> sessionManager.disposeClientSession(getClientId()));
+   }
+
+   protected CompletableFuture<ClientSessionManager> getClientSessionManager() {
+      return getInstance(ClientSessionManager.class);
    }
 
    @Override


### PR DESCRIPTION
This is a proposed fix for https://github.com/eclipse-glsp/glsp/issues/556

The idea behind the fix is to a) make access to the clientidToDiagramEditor Map thread safe and b) to turn off the ActionDispatcher when the editor is about to be closed. This way any actions that are still sent from the client are ignored after the editor was removed from the GLSPEditorRegistry. 