### PR TITLE
GH-743 Change approach to open operating system browser

### DIFF
--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/handlers/ExternalBrowserDebugHandler.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/handlers/ExternalBrowserDebugHandler.java
@@ -15,16 +15,16 @@
  ********************************************************************************/
 package org.eclipse.glsp.ide.editor.handlers;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.awt.Desktop;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
 
 import org.apache.log4j.Logger;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.glsp.ide.editor.ui.GLSPDiagramEditor;
 import org.eclipse.glsp.ide.editor.ui.GLSPIdeEditorPlugin;
-import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.PlatformUI;
 
 public class ExternalBrowserDebugHandler extends IdeActionHandler {
    private static Logger LOG = Logger.getLogger(ExternalBrowserDebugHandler.class);
@@ -43,10 +43,16 @@ public class ExternalBrowserDebugHandler extends IdeActionHandler {
    }
 
    protected void openInExternalBrowser(final String url) {
-      try {
-         PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser().openURL(new URL(url));
-      } catch (PartInitException | MalformedURLException e) {
-         LOG.error("Could not open url in external browser. Url: " + url, e);
+      // Attempt to use the system browser
+      if (Desktop.isDesktopSupported() && Desktop.getDesktop()
+         .isSupported(Desktop.Action.BROWSE)) {
+         try {
+            Desktop.getDesktop().browse(new URI(url));
+         } catch (final IOException | URISyntaxException e) {
+            LOG.error("Could not open url in external browser. Url: " + url, e);
+         }
+      } else {
+         LOG.error("Could not open url in external browser. Desktop is not supported.");
       }
    }
 


### PR DESCRIPTION
The previous approach relied on `PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser().openURL()`, which opens the default handler of .html files (at least in Windows).

This is replaced by a hopefully more reliable approach to open the operating system's browser using java.awt.Desktop.

Closes https://github.com/eclipse-glsp/glsp/issues/743

How to test (e.g., in a Windows VM):
1. Set Windows default handler of `.html` files to something different than the browser: ![Screenshot from 2022-09-23 15-46-16](https://user-images.githubusercontent.com/1155551/191975210-32aa2e8f-d3ae-4e13-ba39-8e0a960628fc.png)
2. Open an example diagram in the WorkflowEditor
3. Start the main menu action Diagram -> Debug (External Browser)
4. Verify that the system's browser correctly opens the diagram