### PR TITLE
Do not dispose client session twice

### DIFF
--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/IdeGLSPClient.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/IdeGLSPClient.java
@@ -70,12 +70,7 @@ public class IdeGLSPClient implements GLSPClient {
     *         otherwise.
     */
    public boolean disconnect(final String clientSessionId, final GLSPClient glspClient) {
-      var result = clientProxies.remove(clientSessionId, glspClient);
-      if (clientProxies.containsKey(clientSessionId)) {
-         return false;
-      }
-      clientSessionManager.disposeClientSession(clientSessionId);
-      return result;
+      return clientProxies.remove(clientSessionId, glspClient);
    }
 
    /**


### PR DESCRIPTION
Fixes https://github.com/eclipse-glsp/glsp/issues/856

The session gets already closed when the part is closed, see `org.eclipse.glsp.ide.editor.ui.GLSPDiagramEditor.notifyAboutToBeDisposed()`.