### PR TITLE
Fix P2 deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,28 +164,9 @@ pipeline {
                 }
                 stage('Deploy server (P2)') {
                     steps {
-                        container('ci') {
-                            timeout(30) {
-                                dir('server') {
-                                    sh "rm -rf ${WORKSPACE}/p2-update-site/ide/p2"
-                                    sh "mkdir -p ${WORKSPACE}/p2-update-site/ide/p2/nightly"
-                                    sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
-                                        sh "mvn clean install -Prelease -B -Dlocal.p2.root=${WORKSPACE}/p2-update-site"
-                                    }
-                                }
-                            }
-                        }
+                        build job: 'deploy-ide-p2-nightly', wait: true
                     }
-
-                    post {
-                        success{
-                            script {
-                                if (env.BRANCH_NAME == 'master') {
-                                    archiveArtifacts artifacts: 'p2-update-site/**', followSymlinks: false 
-                                }
-                            }
-                        }
-                    }
+                
                 }
             }
         }


### PR DESCRIPTION
Apparently the  config of the eclipseglsp/ci:alpine-v4.0 image does not allow proper synching with rsync and ssh. Therefore we execute the p2 deployment in separate job with a proper ssh configuration