### PR TITLE
Propagate the GLSP diagram selection to the Eclipse SelectionService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [diagram] Fixed a bug that could cause a crash when closing a diagram editor on Windows [#59](https://github.com/eclipse-glsp/glsp-eclipse-integration/pull/59)
 - [debug] Fixed a bug to ensure that the system browser opens reliably when using the `Debug (External Browser)` command [#60](https://github.com/eclipse-glsp/glsp-eclipse-integration/pull/60)
 - [websocket] Fixed a bug that could trigger premature session disposal even if other GLSP clients where associated with this session [#63](https://github.com/eclipse-glsp/glsp-eclipse-integration/pull/63)
+- [eclipse] Propagate the GLSP diagram selection to the Eclipse selection service [#73](https://github.com/eclipse-glsp/glsp-eclipse-integration/pull/73) -- Contributed on behalf of STMicroelectronics
 
 ### Breaking Changes
 

--- a/server/example/org.eclipse.glsp.ide.workflow.editor/src/org/eclipse/glsp/ide/workflow/editor/WorkflowGLSPEclipseModule.java
+++ b/server/example/org.eclipse.glsp.ide.workflow.editor/src/org/eclipse/glsp/ide/workflow/editor/WorkflowGLSPEclipseModule.java
@@ -23,6 +23,7 @@ import org.eclipse.glsp.ide.editor.actions.InvokePasteAction;
 import org.eclipse.glsp.ide.editor.actions.NavigateAction;
 import org.eclipse.glsp.ide.editor.actions.RequestExportSvgAction;
 import org.eclipse.glsp.ide.editor.actions.handlers.IdeNavigateToExternalTargetActionHandler;
+import org.eclipse.glsp.ide.editor.actions.handlers.IdeSelectActionHandler;
 import org.eclipse.glsp.ide.editor.actions.handlers.IdeServerMessageActionHandler;
 import org.eclipse.glsp.ide.editor.actions.handlers.IdeServerStatusActionHandler;
 import org.eclipse.glsp.ide.editor.actions.handlers.IdeSetDirtyStateActionHandler;
@@ -68,6 +69,7 @@ class WorkflowGLSPEclipseModule extends WorkflowDiagramModule {
       bindings.add(IdeSetDirtyStateActionHandler.class);
       bindings.add(IdeServerStatusActionHandler.class);
       bindings.add(InitializeCanvasBoundsActionHandler.class);
+      bindings.add(IdeSelectActionHandler.class);
    }
 
    @Override

--- a/server/example/org.eclipse.glsp.ide.workflow.editor/src/org/eclipse/glsp/ide/workflow/editor/WorkflowGLSPEclipseModule.java
+++ b/server/example/org.eclipse.glsp.ide.workflow.editor/src/org/eclipse/glsp/ide/workflow/editor/WorkflowGLSPEclipseModule.java
@@ -24,6 +24,7 @@ import org.eclipse.glsp.ide.editor.actions.NavigateAction;
 import org.eclipse.glsp.ide.editor.actions.RequestExportSvgAction;
 import org.eclipse.glsp.ide.editor.actions.handlers.IdeNavigateToExternalTargetActionHandler;
 import org.eclipse.glsp.ide.editor.actions.handlers.IdeSelectActionHandler;
+import org.eclipse.glsp.ide.editor.actions.handlers.IdeSelectAllActionHandler;
 import org.eclipse.glsp.ide.editor.actions.handlers.IdeServerMessageActionHandler;
 import org.eclipse.glsp.ide.editor.actions.handlers.IdeServerStatusActionHandler;
 import org.eclipse.glsp.ide.editor.actions.handlers.IdeSetDirtyStateActionHandler;
@@ -70,6 +71,7 @@ class WorkflowGLSPEclipseModule extends WorkflowDiagramModule {
       bindings.add(IdeServerStatusActionHandler.class);
       bindings.add(InitializeCanvasBoundsActionHandler.class);
       bindings.add(IdeSelectActionHandler.class);
+      bindings.add(IdeSelectAllActionHandler.class);
    }
 
    @Override

--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/actions/handlers/IdeSelectActionHandler.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/actions/handlers/IdeSelectActionHandler.java
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.ide.editor.actions.handlers;
+
+import java.util.List;
+
+import org.eclipse.glsp.ide.editor.ui.GLSPIdeEditorPlugin;
+import org.eclipse.glsp.server.actions.AbstractActionHandler;
+import org.eclipse.glsp.server.actions.Action;
+import org.eclipse.glsp.server.actions.SelectAction;
+import org.eclipse.glsp.server.model.GModelState;
+
+import com.google.inject.Inject;
+
+/**
+ * Forwards every {@link SelectAction} to the current editor to update its
+ * selection.
+ */
+public class IdeSelectActionHandler extends AbstractActionHandler<SelectAction> {
+
+   @Inject
+   protected GModelState modelState;
+
+   @Override
+   protected List<Action> executeAction(final SelectAction selectAction) {
+      GLSPIdeEditorPlugin.getDefaultGLSPEditorRegistry().getGLSPEditorOrThrow(modelState.getClientId())
+         .updateSelection(selectAction);
+      return none();
+   }
+
+}

--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/actions/handlers/IdeSelectAllActionHandler.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/actions/handlers/IdeSelectAllActionHandler.java
@@ -15,26 +15,38 @@
  ********************************************************************************/
 package org.eclipse.glsp.ide.editor.actions.handlers;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.glsp.ide.editor.ui.GLSPIdeEditorPlugin;
 import org.eclipse.glsp.server.actions.AbstractActionHandler;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.actions.SelectAction;
+import org.eclipse.glsp.server.actions.SelectAllAction;
 import org.eclipse.glsp.server.model.GModelState;
 
 import com.google.inject.Inject;
 
 /**
- * Forwards a {@link SelectAction} to the current editor to update its selection state.
+ * Forwards the selection of an {@link SelectAllAction} to the current editor to update its
+ * selection state.
  */
-public class IdeSelectActionHandler extends AbstractActionHandler<SelectAction> {
+public class IdeSelectAllActionHandler extends AbstractActionHandler<SelectAllAction> {
 
    @Inject
    protected GModelState modelState;
 
    @Override
-   protected List<Action> executeAction(final SelectAction selectAction) {
+   protected List<Action> executeAction(final SelectAllAction selectAllAction) {
+      SelectAction selectAction;
+      if (selectAllAction.isSelect()) {
+         // We don't know on the server which elements are selectable so we just put all
+         // elements of the diagram into the selection state.
+         selectAction = new SelectAction(new ArrayList<>(modelState.getIndex().allIds()));
+      } else {
+         selectAction = new SelectAction(Collections.emptyList(), new ArrayList<>(modelState.getIndex().allIds()));
+      }
       GLSPIdeEditorPlugin.getDefaultGLSPEditorRegistry().getGLSPEditorOrThrow(modelState.getClientId())
          .updateSelection(selectAction);
       return none();

--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/GLSPDiagramEditor.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/GLSPDiagramEditor.java
@@ -18,26 +18,33 @@ package org.eclipse.glsp.ide.editor.ui;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.core.commands.common.EventManager;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.ide.editor.GLSPServerManager;
 import org.eclipse.glsp.ide.editor.actions.GLSPActionProvider;
 import org.eclipse.glsp.ide.editor.actions.InvokeCopyAction;
 import org.eclipse.glsp.ide.editor.actions.InvokeCutAction;
 import org.eclipse.glsp.ide.editor.actions.InvokeDeleteAction;
 import org.eclipse.glsp.ide.editor.actions.InvokePasteAction;
+import org.eclipse.glsp.ide.editor.actions.handlers.IdeSelectActionHandler;
 import org.eclipse.glsp.ide.editor.di.IdeActionDispatcher;
 import org.eclipse.glsp.ide.editor.internal.utils.UrlUtils;
 import org.eclipse.glsp.ide.editor.utils.GLSPDiagramEditorMarkerUtil;
@@ -46,6 +53,7 @@ import org.eclipse.glsp.ide.editor.utils.UIUtil;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.actions.ActionDispatcher;
 import org.eclipse.glsp.server.actions.SaveModelAction;
+import org.eclipse.glsp.server.actions.SelectAction;
 import org.eclipse.glsp.server.actions.SelectAllAction;
 import org.eclipse.glsp.server.actions.ServerStatusAction;
 import org.eclipse.glsp.server.disposable.DisposableCollection;
@@ -60,6 +68,11 @@ import org.eclipse.glsp.server.types.GLSPServerException;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.ProgressListener;
@@ -81,7 +94,7 @@ import org.eclipse.ui.part.EditorPart;
 
 import com.google.inject.Injector;
 
-public class GLSPDiagramEditor extends EditorPart implements IGotoMarker {
+public class GLSPDiagramEditor extends EditorPart implements IGotoMarker, ISelectionProvider {
    /**
     * {@link IEclipseContext} key for the current client id. The associated value
     * is a {@link String}.
@@ -102,6 +115,9 @@ public class GLSPDiagramEditor extends EditorPart implements IGotoMarker {
 
    protected final CompletableFuture<Injector> injector = new CompletableFuture<>();
    protected boolean dirty;
+
+   protected final SelectionManager selectionListener = new SelectionManager();
+   private StructuredSelection currentSelection = StructuredSelection.EMPTY;
 
    protected final DisposableCollection toDispose = new DisposableCollection();
 
@@ -308,10 +324,12 @@ public class GLSPDiagramEditor extends EditorPart implements IGotoMarker {
 
       setPartName(generatePartName());
 
-      this.browser = createBrowser(root);
+      browser = createBrowser(root);
       setupBrowser(this.browser);
 
-      this.statusBar = createStatusBar(root);
+      statusBar = createStatusBar(root);
+
+      getSite().setSelectionProvider(this);
    }
 
    protected String generatePartName() {
@@ -454,4 +472,110 @@ public class GLSPDiagramEditor extends EditorPart implements IGotoMarker {
          }
       };
    }
+
+   protected static class SelectionManager extends EventManager {
+
+      public void addSelectionChangedListener(final ISelectionChangedListener listener) {
+         addListenerObject(listener);
+      }
+
+      public void removeSelectionChangedListener(final ISelectionChangedListener listener) {
+         removeListenerObject(listener);
+      }
+
+      public void selectionChanged(final SelectionChangedEvent event) {
+         for (Object listener : getListeners()) {
+            final ISelectionChangedListener selectionChangedListeners = (ISelectionChangedListener) listener;
+            UIUtil.asyncExec(() -> selectionChangedListeners.selectionChanged(event));
+         }
+      }
+
+   }
+
+   @Override
+   public void addSelectionChangedListener(final ISelectionChangedListener listener) {
+      selectionListener.addSelectionChangedListener(listener);
+   }
+
+   @Override
+   public void removeSelectionChangedListener(final ISelectionChangedListener listener) {
+      selectionListener.removeSelectionChangedListener(listener);
+   }
+
+   @Override
+   public ISelection getSelection() { return currentSelection; }
+
+   /**
+    * Sets the selection on the client by dispatching a corresponding
+    * {@link SelectAction}.
+    * <p>
+    * If a {@link IdeSelectActionHandler} is installed on the server, this will
+    * also eventually invoke {@link #updateSelection(SelectAction)} to update the
+    * {@link #currentSelection} in this editor object and notify the registered
+    * selection listeners.
+    * </p>
+    */
+   @Override
+   public void setSelection(final ISelection selection) {
+      if (!(selection instanceof StructuredSelection)) {
+         return;
+      }
+
+      getModelStateOnceInitialized().thenAccept(modelState -> {
+         StructuredSelection structuredSelection = (StructuredSelection) selection;
+         List<String> elementIdsToSelect = toGModelElementStream(structuredSelection).map(GModelElement::getId)
+            .collect(Collectors.toList());
+         Set<String> elementIdsToDeselect = modelState.getIndex().allIds();
+         elementIdsToDeselect.removeAll(elementIdsToSelect);
+         dispatch(new SelectAction(elementIdsToSelect, new ArrayList<>(elementIdsToDeselect)));
+      });
+   }
+
+   /**
+    * Updates the currently selected elements.
+    * <p>
+    * In contrast to {@link #setSelection(ISelection)}, this method does not change
+    * the selection on the client but only notifies the selection listeners and
+    * updates the list of currently selected elements in this editor object.
+    * </p>
+    * <p>
+    * This method is usually invoked by the {@link IdeSelectActionHandler}, which
+    * reacts to the {@link SelectAction} (e.g. triggered by the client on select)
+    * to update the selection and notify listeners in Eclipse.
+    * </p>
+    *
+    * @param selectAction the {@link SelectAction}
+    */
+   public void updateSelection(final SelectAction selectAction) {
+      getModelStateOnceInitialized().thenAccept(modelState -> {
+         List<GModelElement> selection = toGModelElementStream(currentSelection).collect(Collectors.toList());
+
+         List<String> selectedIds = selectAction.getSelectedElementsIDs();
+         List<String> deselectedIds = selectAction.getDeselectedElementsIDs();
+         List<GModelElement> selectedGModelElements = toGModelElements(selectedIds, modelState);
+         List<GModelElement> deselectedGModelElements = toGModelElements(deselectedIds, modelState);
+
+         selection.removeAll(deselectedGModelElements);
+
+         for (GModelElement newSelectedElement : selectedGModelElements) {
+            if (!selection.contains(newSelectedElement)) {
+               selection.add(newSelectedElement);
+            }
+         }
+         final List<GModelElement> selectedGModelElements1 = selection;
+
+         currentSelection = new StructuredSelection(selectedGModelElements1);
+         selectionListener.selectionChanged(new SelectionChangedEvent(this, currentSelection));
+      });
+   }
+
+   @SuppressWarnings("unchecked")
+   protected Stream<GModelElement> toGModelElementStream(final StructuredSelection selection) {
+      return selection.toList().stream().filter(GModelElement.class::isInstance).map(GModelElement.class::cast);
+   }
+
+   protected List<GModelElement> toGModelElements(final List<String> ids, final GModelState modelState) {
+      return ids.stream().map(modelState.getIndex()::get).flatMap(Optional::stream).collect(Collectors.toList());
+   }
+
 }


### PR DESCRIPTION
This can best be tested by setting a breakpoint in the `org.eclipse.ui.internal.e4.compatibility.SelectionService`.

Fixes https://github.com/eclipse-glsp/glsp/issues/899
Contributed on behalf of STMicroelectronics