### PR TITLE
Update GLSP version of minimum baseline target

### DIFF
--- a/server/releng/org.eclipse.glsp.ide.releng.target/r2021-09_minimum_baseline.target
+++ b/server/releng/org.eclipse.glsp.ide.releng.target/r2021-09_minimum_baseline.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="2021-09 - Minimum Baseline" sequenceNumber="1674515936">
+<target name="2021-09 - Minimum Baseline" sequenceNumber="1677063068">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.platform.feature.group" version="4.21.0.v20210906-0842"/>
@@ -25,7 +25,7 @@
       <unit id="org.eclipse.glsp.server.websocket" version="0.0.0"/>
       <unit id="org.eclipse.glsp.layout" version="0.0.0"/>
       <unit id="org.eclipse.glsp.example.workflow" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202301232259/"/>
+      <repository location="https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202301302251/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.elk.core" version="0.8.1"/>

--- a/server/releng/org.eclipse.glsp.ide.releng.target/r2021-09_minimum_baseline.tpd
+++ b/server/releng/org.eclipse.glsp.ide.releng.target/r2021-09_minimum_baseline.tpd
@@ -16,7 +16,7 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R202211230215
 	com.google.inject
 }
 
-location "https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202301232259/" {
+location "https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202301302251/" {
 	org.eclipse.glsp.feature.feature.group lazy
 	org.eclipse.glsp.feature.source.feature.group lazy
 	org.eclipse.glsp.server.websocket lazy


### PR DESCRIPTION
Align GLSP version of minimum base line target with the default target. Follow-up of #72