### PR TITLE
Fixes Duplicate Key Binding Triggers on WebKit

### DIFF
--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/GLSPDiagramComposite.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/GLSPDiagramComposite.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.core.commands.common.EventManager;
 import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.ide.editor.GLSPServerManager;
@@ -332,7 +333,9 @@ public class GLSPDiagramComposite implements IGotoMarker, ISelectionProvider {
 
    protected void installBrowserFunctions() {
       // browser functions are automatically disposed with the browser
-      new BrowserKeyBindingForwarderInstaller(context.get(IBindingService.class)).install(browser);
+      if (Platform.getOS().equals(Platform.WS_WIN32)) {
+         new BrowserKeyBindingForwarderInstaller(context.get(IBindingService.class)).install(browser);
+      }
       new BrowserFocusControlInstaller().install(browser);
       new BrowserContextMenuInstaller().install(browser);
    }


### PR DESCRIPTION
Fixes eclipse-glsp/glsp#874
Without this fix there are duplicated Key Binding Triggers on WebKit as the fix provided by BrowserKeyBindingForwarderInstaller is only an Issue on Chrome and Edge

#### What it does

Fixes Duplicate Key Binding Triggers on WebKit

#### How to test

Start the example on Windows and Linux,
Set the Focus in the Web browser View
Make sure that in both cases, Ctrl+H opens the Eclipse Search once.

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
