### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Eclipse GLSP Eclipse Integration Changelog
 
+## v2.7.0 - active
+
+### Changes
+
+-   [deps] Migrate to ESLint 9.x [#124](https://github.com/eclipse-glsp/glsp-eclipse-integration/pull/124)
+
+### Potentially Breaking Changes
+
+-   [node] Upgrade to Node 22 as new minimum version [#128](https://github.com/eclipse-glsp/glsp-eclipse-integration/pull/128)
+
 ## [v2.6.0 - 11/02/2026](https://github.com/eclipse-glsp/glsp-eclipse-integration/releases/tag/v2.6.0)
 
 ### Changes


### PR DESCRIPTION
#### What it does

Updates the changelog with entries for changes merged since the `v2.6.0` release. Introduces a new active `v2.7.0` section:

- [deps] Migrate to ESLint 9.x ([#124](https://github.com/eclipse-glsp/glsp-eclipse-integration/pull/124))
- [node] Upgrade to Node 22 as new minimum version ([#128](https://github.com/eclipse-glsp/glsp-eclipse-integration/pull/128)) — listed under *Potentially Breaking Changes*

#### How to test

Review the rendered `CHANGELOG.md` for correctness and formatting.

#### Follow-ups

None.

#### Changelog

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)