### PR TITLE
Update GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.x
       - name: Build
@@ -34,8 +34,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.x
       - name: Install

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,16 +37,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: 21
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@16df4fbc19aea13d921737861d6c622bf3cefe23 # v2.23.0
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -59,7 +59,7 @@ jobs:
         working-directory: server
 
       - name: Build Client with yarn
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
       - run: yarn install
@@ -76,4 +76,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@16df4fbc19aea13d921737861d6c622bf3cefe23 # v2.23.0
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository == 'eclipse-glsp/glsp-eclipse-integration' && (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || (github.event.workflow_run.conclusion == 'success'))
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref || github.event.inputs.ref || github.event.workflow_run.head_commit.id || github.sha }}
           # Fetch all history for lerna to determine versions
@@ -64,7 +64,7 @@ jobs:
             echo "should_publish=true" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: steps.check_changes.outputs.should_publish == 'true'
         with:
           node-version: 22.x


### PR DESCRIPTION
#### What it does

Updates the pinned versions of the external GitHub Actions used in the CI/release workflows to the latest eligible stable releases. All external actions remain pinned to a full commit SHA with a same-line version comment, per the repository's action-pinning policy.

- actions/checkout -> v6.0.3
- actions/setup-node -> v6.4.0
- actions/setup-java -> v5.2.0
- github/codeql-action/init -> v4.36.1
- github/codeql-action/analyze -> v4.36.1

#### How to test

The workflows run on this PR. Verify that all CI jobs (build/lint, CodeQL, e2e, etc.) complete successfully against the bumped action versions.

#### Follow-ups

None.

#### Changelog

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)